### PR TITLE
Update to include instructions for building from a GIT clone, as the repo

### DIFF
--- a/README
+++ b/README
@@ -12,3 +12,5 @@ To build and install it, just ...
 
  ... and it's there.
 
+If building from a GIT clone, you'll need to run ./autogen.sh first (see the HACKING file)
+


### PR DESCRIPTION
Update to include instructions for building from a GIT clone, as the repository doesn't include a configure file (it must be generated with autogen)
