### PR TITLE
Added posterize filter to PNG24 target

### DIFF
--- a/src/webx_png24_target.h
+++ b/src/webx_png24_target.h
@@ -48,9 +48,11 @@ struct _WebxPng24Target
   gint          time;
   gint          comment;
   gint          svtrans;
+  gint          posterize;
 
   GtkObject    *interlace_o;
   GtkObject    *compression_o;
+  GtkObject    *posterize_o;
 };
 
 struct _WebxPng24TargetClass


### PR DESCRIPTION
See ticket #23 

I've tried my hand at adding posterizing but I was running into the issue that once it had been applied at …say 2, turning posterization back up to …say 100 had no effect on the preview and the saved image.

So I did what the JPEG export does: duplicate the image (to get a new image) and then flatten it (to get a new layer). No idea if that's any good, but it works.

This is my 1st time ever using both C and GIMP code. Sorry, if I missed something obvious.